### PR TITLE
Implement mission joining and leaving

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,11 +1,19 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Table, Button } from 'react-bootstrap';
-import { fetchMissions } from '../redux/missions/missions';
+import { fetchMissions, joinMissions, leaveMission } from '../redux/missions/missions';
 
 const Missions = () => {
   const newMissions = useSelector((state) => state.mission);
   const dispatch = useDispatch();
+
+  const joinHandler = (id) => {
+    dispatch(joinMissions(id));
+  };
+
+  const leaveMissionHandler = (id) => {
+    dispatch(leaveMission(id));
+  };
 
   useEffect(() => {
     if (fetchMissions.isLoading === false) {
@@ -26,14 +34,14 @@ const Missions = () => {
         </thead>
         <tbody>
           {receivedMissions.map((mission) => (
-            <tr key={mission.mission_id}>
-              <td>{mission.mission_name}</td>
+            <tr key={mission.missionId}>
+              <td>{mission.missionName}</td>
               <td>{mission.description}</td>
               <td>
-                <Button variant="secondary" type="button">Not a member</Button>
+                <span>{mission.reserved ? <Button type="button">Active Member</Button> : <Button type="button" variant="secondary">Not a member</Button>}</span>
               </td>
               <td>
-                <Button variant="outline-dark" type="button">Join Mission</Button>
+                <span>{mission.reserved ? <Button type="button" variant="outline-danger" onClick={() => { leaveMissionHandler(mission.missionId); }}>Leave Reservation</Button> : <Button variant="outline-dark" type="submit" onClick={() => joinHandler(mission.missionId)}>Join Mission</Button>}</span>
               </td>
             </tr>
           ))}

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -4,41 +4,83 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 const GET_MISSIONS = 'spaceTravelersHub/missions/GET_MISSIONS';
 const URL = 'https://api.spacexdata.com/v3/missions';
 
+const initialState = {
+  isLoading: true,
+  missions: [],
+};
+
 export const fetchMissions = createAsyncThunk(
   GET_MISSIONS,
   async () => {
     try {
       const response = await axios.get(URL);
-      return response.data;
+
+      const data = [];
+
+      response.data.forEach((obj) => {
+        const {
+          mission_id: missionId, mission_name: missionName, description,
+        } = obj;
+
+        const formatedData = {
+          missionId,
+          missionName,
+          description,
+          reserved: false,
+        };
+
+        data.push(formatedData);
+      });
+
+      return data;
     } catch (error) {
       return error;
     }
   },
 );
 
-const initialState = {
-  isLoading: true,
-  missions: [],
-};
-
-const createApiSlice = createSlice(
-  {
-    name: 'missions',
-    initialState,
-    reducers: [],
-    extraReducers: {
-      [fetchMissions.fulfilled]: (state, action) => {
-        state.isLoading = false;
-        state.missions = action.payload;
-      },
-      [fetchMissions.pending]: (state) => {
-        state.isLoading = true;
-      },
-      [fetchMissions.rejected]: (state) => {
-        state.isLoading = false;
-      },
+const createApiSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {
+    joinMissions: (state, action) => ({
+      ...state,
+      missions: state.missions.map((mission) => {
+        if (mission.missionId === action.payload) {
+          return {
+            ...mission,
+            reserved: true,
+          };
+        }
+        return { ...mission };
+      }),
+    }),
+    leaveMission: (state, action) => ({
+      ...state,
+      missions: state.missions.map((mission) => {
+        if (mission.missionId === action.payload) {
+          return {
+            ...mission,
+            reserved: false,
+          };
+        }
+        return { ...mission };
+      }),
+    }),
+  },
+  extraReducers: {
+    [fetchMissions.fulfilled]: (state, action) => {
+      state.isLoading = false;
+      state.missions = action.payload;
+    },
+    [fetchMissions.pending]: (state) => {
+      state.isLoading = true;
+    },
+    [fetchMissions.rejected]: (state) => {
+      state.isLoading = false;
     },
   },
-);
+});
 
+export const { joinMissions, leaveMission } = createApiSlice.actions;
 export default createApiSlice.reducer;


### PR DESCRIPTION
## In this branch

- [ ] When a user clicks the "Join Mission" button, an action is dispatched to update the store. 
- [ ] The ID of the selected mission is used to update the state.
- [ ] The selected mission is given an extra key reserved with its value set to true. 
- [ ] The map() method is used to set the value of the new state.
- [ ] In the React view file, the action is dispatched with the correct rocket ID as an argument.
- [ ] The same logic is applied from the "Join mission" applied to the ''Leave mission'' - but the reserved key is set to false.
- [ ] Dispatch these actions upon clicking on the corresponding buttons.
- [ ] Missions that the user has joined already show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
